### PR TITLE
Changed input format order.

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -21,6 +21,7 @@ class BootstrapFormHelper extends FormHelper {
 			'before' => null, // to convert .input-prepend
 			'after' => null, // to convert .help-block
 			'div' => array(),
+			'format' => array('before', 'label', 'between', 'input', 'error', 'after'),
 		);
 		$options = Set::merge($default, $options);
 


### PR DESCRIPTION
Changed the default input format order ('before', 'label', 'between', 'input', 'after', 'error') to ('before', 'label', 'between', 'input', 'error', 'after'), so <code>&lt;span class="help-inline"&gt;ERRORMESSAGE&lt;/span&gt;</code> is before <code>&lt;p class="help-block" style=""&gt;HELPLABEL&lt;/p&gt;</code>. Otherwise the help-inline-element is not shown inline with the input-field.
