### PR TITLE
Fixed typo and add default value (null) to BootstrapFormHelper::create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Controller/AppController.php
 			'Session',
 			'Html' => array('className' => 'TwitterBootstrap.BootstrapHtml'),
 			'Form' => array('className' => 'TwitterBootstrap.BootstrapForm'),
-			'Pagenator' => array('className' => 'TwitterBootstrap.BootstrapPaginator'),
+			'Paginator' => array('className' => 'TwitterBootstrap.BootstrapPaginator'),
 		);
 	}
 

--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -6,7 +6,7 @@ class BootstrapFormHelper extends FormHelper {
 
 	public $helpers = array('Html');
 
-	public function create($model, $options = array()) {
+	public function create($model = null, $options = array()) {
 		$default = array(
 			'class' => 'form-horizontal',
 		);


### PR DESCRIPTION
'Pagenator' is wrong, 'Paginator' is valid.

First parameter of FormHelper::create() is "$model = null", but first parameter of BootstrapFormHelper::create() is "$model".
I userd BootstrapFormHelper in scaffold view,  I had Warning and Notice for this function.
