### PR TITLE
Small change to BootstrapHtmlHelper & Rework of CopyShell

### DIFF
--- a/Console/Command/CopyShell.php
+++ b/Console/Command/CopyShell.php
@@ -10,11 +10,81 @@ class CopyShell extends AppShell {
 
 	const LESS_DIR = 'less';
 
+	protected $_Theme = null;
+
+	protected $_Action = null;
+
 	public $pluginPath = null;
 
 	public $bootstrapPath = null;
 
 	public $Folder = null;
+
+	public function getOptionParser() {
+		$options = array(
+			'theme' => array(
+				'short' => 't',
+				'help' => __('Set theme to place Bootstrap files in.'),
+				'boolean' => false
+			),
+			'webroot' => array(
+				'short' => 'w',
+				'help' => __('Set file output to webroot Theme dir (use with theme option).'),
+				'boolean' => true
+			)
+		);
+
+		return ConsoleOptionParser::buildFromArray(array(
+			'command' => 'copy',
+			'description' => __('TwitterBootstrap Copy Shell Help.'),
+			'options' => array(
+				'theme' => $options['theme'],
+				'webroot' => $options['webroot']
+			),
+			'subcommands' => array(
+				'all' => array(
+					'help' => __('Copies Less, Js & Img source from Bootstrap submodule in plugin Vendor dir'),
+					'parser' => array(
+						'description' => array(__('files will be placed in webroot of App or named Theme')),
+						'options' => array(
+							'theme' => $options['theme'],
+							'webroot' => $options['webroot']
+						),
+					)
+				),
+				'less' => array(
+					'help' => __('Copies Less source from Bootstrap submodule in plugin Vendor dir'),
+					'parser' => array(
+						'description' => array(__('files will be placed in webroot/css/lib/ of App or named Theme')),
+						'options' => array(
+							'theme' => $options['theme'],
+							'webroot' => $options['webroot']
+						),
+					)
+				),
+				'img' => array(
+					'help' => __('Copies Img source from Bootstrap submodule in plugin Vendor dir'),
+					'parser' => array(
+						'description' => array(__('files will be placed in webroot/img/ of App or named Theme')),
+						'options' => array(
+							'theme' => $options['theme'],
+							'webroot' => $options['webroot']
+						),
+					)
+				),
+				'js' => array(
+					'help' => __('Copies Js source from Bootstrap submodule in plugin Vendor dir'),
+					'parser' => array(
+						'description' => array(__('files will be placed in webroot/js/lib of App or named Theme')),
+						'options' => array(
+							'theme' => $options['theme'],
+							'webroot' => $options['webroot']
+						),
+					)
+				)
+			)
+		));
+	}
 
 	public function initialize() {
 		$this->pluginPath = dirname(dirname(dirname(__FILE__))) . DS;
@@ -24,9 +94,27 @@ class CopyShell extends AppShell {
 	}
 
 	public function main() {
-		$this->copyLess();
-		$this->copyImg();
-		$this->copyJs();
+		if (isset($this->params['theme'])) {
+			$this->_Theme = $this->params['theme'];
+		}
+
+		$this->_Action = isset($this->args[0]) ? $this->args[0] : 'all';
+		switch ($this->_Action) {
+			case 'js':
+				$this->copyJs();
+				break;
+			case 'less':
+				$this->copyLess();
+				break;
+			case 'img':
+				$this->copyImg();
+				break;
+			default:
+				$this->copyLess();
+				$this->copyImg();
+				$this->copyJs();
+				break;
+		}
 	}
 
 	protected function _copy($options) {
@@ -36,29 +124,56 @@ class CopyShell extends AppShell {
 			'skip' => array('tests', 'README.md'),
 		);
 		$options += $default;
-		$this->out('Copy from ' . $options['from'] . ' to ' . $options['to']);
+
+		$this->out('<comment>From: ' . str_replace(APP, '', $options['from']) . "\n" .
+			 'To: ' . str_replace(APP, '', $options['to']) . '</comment>', 1, Shell::VERBOSE);
+
 		if ($this->Folder->copy($options)) {
-			$this->out('Success.');
+			$this->out('<info>' . __('Success.', 'TwitterBootstrap') . '</info>');
 		} else {
-			$this->out('Error!');
+			$this->out('<error>' . __('Error!', 'TwitterBootstrap') . '</error>');
 		}
 	}
 
 	public function copyLess() {
 		$from = $this->bootstrapPath . self::LESS_DIR;
-		$to = WWW_ROOT . 'css' . DS . 'lib';
+		$to = '';
+		if ($this->_Theme && !isset($this->params['webroot'])) {
+			$to = APP . 'View' . DS . 'Themed' . DS . $this->_Theme . DS . 'webroot' . DS . 'css' . DS . 'lib';
+		} elseif ($this->_Theme && isset($this->params['webroot'])) {
+			$to = WWW_ROOT . 'theme' . DS . $this->_Theme . DS . 'css' . DS . 'lib';
+		} else {
+			$to = WWW_ROOT . 'css' . DS . 'lib';
+		}
+		$this->out('<info>Copying Less</info>');
 		$this->_copy(compact('from', 'to'));
 	}
 
 	public function copyImg() {
 		$from = $this->bootstrapPath . self::IMG_DIR;
-		$to = WWW_ROOT . 'img';
+		$to = '';
+		if ($this->_Theme && !isset($this->params['webroot'])) {
+			$to = APP . 'View' . DS . 'Themed' . DS . $this->_Theme . DS . 'webroot' . DS . 'img';
+		} elseif ($this->_Theme && isset($this->params['webroot'])) {
+			$to = WWW_ROOT . 'theme' . DS . $this->_Theme . DS . 'img';
+		} else {
+			$to = WWW_ROOT . 'img';
+		}
+		$this->out('<info>Copying Images</info>');
 		$this->_copy(compact('from', 'to'));
 	}
 
 	public function copyJs() {
 		$from = $this->bootstrapPath . self::JS_DIR;
-		$to = WWW_ROOT . 'js' . DS . 'lib';
+		$to = '';
+		if ($this->_Theme && !isset($this->params['webroot'])) {
+			$to = APP . 'View' . DS . 'Themed' . DS . $this->_Theme . DS . 'webroot' . DS . 'js' . DS . 'lib';
+		} elseif ($this->_Theme && isset($this->params['webroot'])) {
+			$to = WWW_ROOT . 'theme' . DS . $this->_Theme . DS . 'js' . DS . 'lib';
+		} else {
+			$to = WWW_ROOT . 'js' . DS . 'lib';
+		}
+		$this->out('<info>Copying Javascript</info>');
 		$this->_copy(compact('from', 'to'));
 	}
 

--- a/Console/Command/CopyShell.php
+++ b/Console/Command/CopyShell.php
@@ -24,9 +24,9 @@ class CopyShell extends AppShell {
 	}
 
 	public function main() {
-		$this->copy_less();
-		$this->copy_img();
-		$this->copy_js();
+		$this->copyLess();
+		$this->copyImg();
+		$this->copyJs();
 	}
 
 	protected function _copy($options) {
@@ -44,19 +44,19 @@ class CopyShell extends AppShell {
 		}
 	}
 
-	public function copy_less() {
+	public function copyLess() {
 		$from = $this->bootstrapPath . self::LESS_DIR;
 		$to = WWW_ROOT . 'css' . DS . 'lib';
 		$this->_copy(compact('from', 'to'));
 	}
 
-	public function copy_img() {
+	public function copyImg() {
 		$from = $this->bootstrapPath . self::IMG_DIR;
 		$to = WWW_ROOT . 'img';
 		$this->_copy(compact('from', 'to'));
 	}
 
-	public function copy_js() {
+	public function copyJs() {
 		$from = $this->bootstrapPath . self::JS_DIR;
 		$to = WWW_ROOT . 'js' . DS . 'lib';
 		$this->_copy(compact('from', 'to'));

--- a/View/Helper/BootstrapHtmlHelper.php
+++ b/View/Helper/BootstrapHtmlHelper.php
@@ -27,6 +27,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
 			}
 			$title = $this->icon($options['icon']) . ' ' . $title;
 			$options['escape'] = false;
+			unset($options['icon']);
 		}
 		return parent::link($title, $url, $options, $confirmMessage);
 	}


### PR DESCRIPTION
1) BootstrapHtmlHelper output icon as attribute when passed to link method - unset before generating link
2) change some method names in keeping with Coding Standards
3) Various options for copy shell:
 a) Theme support including output to webroot/theme/ThemeName
 b) can copy all, less, images or js

I have also tried to enable the many of the same options to the MakeShell in a new branch
https://github.com/sams/TwitterBootstrap/tree/MakeOptions
