### PR TITLE
Add class "control-group" to vertical-form, not just horizontal-form

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -147,10 +147,8 @@ class BootstrapFormHelper extends FormHelper {
 
 		if (in_array(self::FORM_SEARCH, $class) || in_array(self::FORM_INLINE, $class)) {
 			$options['inputDefaults'] = Set::merge($inputDefaults, array('div' => false, 'label' => false));
-		} elseif (in_array(self::FORM_HORIZONTAL, $class)) {
-			$options['inputDefaults'] = Set::merge($inputDefaults, array('div' => self::CLASS_GROUP));
 		} else {
-			$options['inputDefaults'] = Set::merge($inputDefaults, array('div' => null));
+			$options['inputDefaults'] = Set::merge($inputDefaults, array('div' => self::CLASS_GROUP));
 		}
 
 		return parent::create($model, $options);


### PR DESCRIPTION
This is needed to display warning/error/success stylings. I don't see any mention in the Bootstrap documentation that says `control-group` is only for `horizontal-form`s. In fact, Mark Otto uses `control-group` in a `vertical-form` in his blog entry: http://www.markdotto.com/2011/10/10/help-us-refactor-forms-for-bootstrap-2-0/
