### PR TITLE
Added a check to suppress an error when $this->Form->input() is called w...

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -339,12 +339,14 @@ class BootstrapFormHelper extends FormHelper {
 		}
 		if ($this->error($fieldName)) {
 			$error = $this->_extractOption('error', $options, array());
-			$options['error'] = array_merge($error, array(
-				'attributes' => array(
-					'wrap' => 'span',
-					'class' => 'help-inline error-message',
-				),
-			));
+			if (false !== $error) {
+				$options['error'] = array_merge($error, array(
+					'attributes' => array(
+						'wrap' => 'span',
+						'class' => 'help-inline error-message',
+					),
+				));
+			}
 			if (false !== $div) {
 				$options = $this->addClass($options, self::CLASS_ERROR, 'div');
 			}


### PR DESCRIPTION
This pull is a hack to avoid a problem which cause warning when using formHelper->input with an option "'error' => false" like:
`echo $this->Form->input('field',  array ( 'error' => false) ) ;`
that causes a warning:
`Warning (2): array_merge() [function.array-merge]: Argument #1 is not an array`
