### PR TITLE
fixed parameter not to get warning.

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -81,11 +81,11 @@ class BootstrapFormHelper extends FormHelper {
 	}
 
 	public function checkbox($fieldName, $options = array()) {
-		$label = $this->_extractOption('label', $this->_Opts[$fieldName]);
+		$label = $this->_extractOption('label', $options);
 		if (!is_array($label)) {
 			$label = array('text' => $label);
 		}
-		$after = $this->_extractOption('after', $this->_Opts[$fieldName]);
+		$after = $this->_extractOption('after', $options);
 
 		if ($this->_isHorizontal) {
 			$label['text'] = $after;


### PR DESCRIPTION
Hello, I made a tiny hack which avoids:
'Undefined index:' notice in APP/Plugin/TwitterBootstrap/View/Helper/BootstrapFormHelper.php,
also 'The second argument should be either an array or an object' warning in CORE/Cake/View/Helper/FormHelper.php.
when $this->Form->checkbox('foo') is called.
