### PR TITLE
Fixing problem when passing the $options in the $model

### DIFF
--- a/Test/Case/View/Helper/BootstrapFormHelperTest.php
+++ b/Test/Case/View/Helper/BootstrapFormHelperTest.php
@@ -41,6 +41,17 @@ class BootstrapFormHelperTest extends CakeTestCase {
 		$expected = '<form action="/" id="Form" method="post" accept-charset="utf-8">' .
 			'<div style="display:none;"><input type="hidden" name="_method" value="POST"></div>';
 		$this->assertSame($expected, $form);
+		$form = $this->BootstrapForm->create(
+			array(
+				'url' => array(
+					'controller' => 'test',
+					'action' => 'testing'
+				)
+			)
+		);
+		$expected = '<form action="/test/testing" id="Form" method="post" accept-charset="utf-8">' .
+			'<div style="display:none;"><input type="hidden" name="_method" value="POST"></div>';
+		$this->assertSame($expected, $form);		
 	}
 
 /**

--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -144,6 +144,10 @@ class BootstrapFormHelper extends FormHelper {
 	}
 
 	public function create($model = null, $options = array()) {
+		if (is_array($model) && empty($options)) {
+			$options = $model;
+			$model = null;
+		}
 		$class = explode(' ', $this->_extractOption('class', $options));
 		$inputDefaults = $this->_extractOption('inputDefaults', $options, array());
 


### PR DESCRIPTION
FormHelper::create supports pass the $options as the first argument, in this case BootstrapFormHelper should consider $model as $options
