### PR TITLE
Added windows compatible commands

### DIFF
--- a/Console/Command/MakeShell.php
+++ b/Console/Command/MakeShell.php
@@ -10,11 +10,17 @@ class MakeShell extends TwitterBootstrapAppShell {
 	public function main() {
 		$bootstrapLess = WWW_ROOT . self::BOOTSTRAP_LESS;
 		$responsiveLess = WWW_ROOT . self::RESPONSIVE_LESS;
+		$isWindows = strpos(PHP_OS, 'WIN');
 
 		$command = "cd {$this->bootstrapPath} && ";
 		$command .= "make bootstrap BOOTSTRAP_LESS='{$bootstrapLess}' BOOTSTRAP_RESPONSIVE_LESS='{$responsiveLess}' && ";
-		$command .= "cp -R bootstrap/* " . WWW_ROOT . " && ";
-		$command .= "rm -rf bootstrap";
+		if ($isWindows) {
+			$command .= "xcopy /s /e /y bootstrap/* " . WWW_ROOT . " && ";
+			$command .= "rmdir /s /q bootstrap";
+		} else {
+			$command .= "cp -R bootstrap/* " . WWW_ROOT . " && ";
+			$command .= "rm -rf bootstrap";
+		}
 
 		exec($command, $output);
 		$this->out($output);


### PR DESCRIPTION
As per https://github.com/twitter/bootstrap/pull/3185 , Windows users can make use of the make tool. However, the CakeShell scripts make use of *Nix specific commands. This will detect if you are on a Windows machine and run the appropriate Windows commands.
