### PR TITLE
Allow to override which model is used in the pagination() method

### DIFF
--- a/View/Helper/BootstrapPaginatorHelper.php
+++ b/View/Helper/BootstrapPaginatorHelper.php
@@ -7,8 +7,10 @@ class BootstrapPaginatorHelper extends PaginatorHelper {
 		$default = array(
 			'div' => 'pagination pagination-centered'
 		);
+		
+		$model = (empty($options['model'])) ? $this->defaultModel() : $options['model'];
 
-		$pagingParams = reset($this->request->params['paging']);
+		$pagingParams = $this->request->params['paging'][$model];
 		$pageCount = $pagingParams['pageCount'];
 
 		if ($pageCount < 2) {


### PR DESCRIPTION
It will use the default model if none is specified, but you can override it by setting $options['model'].
