### PR TITLE
fix _restructureLabel removed inner <label for="..."> tags

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -135,7 +135,7 @@ class BootstrapFormHelper extends FormHelper {
 	protected function _restructureLabel($out, $options = array()) {
 		$out = explode("\n", $out);
 		foreach ($out as $key => &$_out) {
-			$input = strip_tags($_out, '<input><img>');
+			$input = strip_tags($_out, '<input><img><label>');
 			if ($input) {
 				$_out = $this->Html->tag('label', $input, $options);
 			}


### PR DESCRIPTION
ex:
CakePHP original form helper output:
 <input name="data[test]" id="TestTest_" value="" type="hidden"><input name="data[test]" id="TestTestOne" value="One" type="radio"><label for="TestTestOne">One</label>
TwitterBootstrap form helper output:
 <label class="radio"><input name="data[test]" id="TestTest_" value="" type="hidden"><input name="data[test]" id="TestTestOne" value="One" type="radio">One</label>
Patched TwitterBootstrap form helper output:
 <label class="radio"><input name="data[test]" id="TestTest_" value="" type="hidden"><input name="data[test]" id="TestTestOne" value="One" type="radio"><label for="TestTestOne">One</label></label>
