### PR TITLE
Fixed input generation for CakePHP 2.4

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -35,7 +35,7 @@ class BootstrapFormHelper extends FormHelper {
 			}
 			return $options;
 		} else {
-			return $this->Html->tag('span', $options['value'], $options['class']);
+			return $this->Html->tag('span', $options['value'], $options);
 		}
 	}
 

--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -247,7 +247,7 @@ class BootstrapFormHelper extends FormHelper {
 		$input = $hidden . ((false === $div) ? $input : $this->Html->div($divControls, $input));
 
 		$out = $before . $label . $between . $input;
-		return (false === $div) ? $out : $this->Html->tag('div', $out, $div);
+		return (false === $div) ? $out : $this->Html->tag('div', $out, array('class' => $div));
 	}
 
 	protected function _getType($fieldName, $options) {


### PR DESCRIPTION
Fixed input generation for CakePHP 2.4; third parameter of HtmlHelper->tag() should be an array. In previous versions a string was processed as an array with one entry "class".
