### PR TITLE
Better handle normal forms following isHorizontal forms on the same page...

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -149,6 +149,8 @@ class BootstrapFormHelper extends FormHelper {
 
 		if (in_array(self::FORM_HORIZONTAL, $class)) {
 			$this->_isHorizontal = true;
+		} else {
+			$this->_isHorizontal = false;
 		}
 
 		if (in_array(self::FORM_SEARCH, $class) || in_array(self::FORM_INLINE, $class)) {


### PR DESCRIPTION
Howdy. I noticed that when a normal form follows an isHorizontal form, the isHorizontal flag never gets cleared. I haven't done a ton of testing on this change, but it works for my use case.
